### PR TITLE
[codex] Refresh theme UI

### DIFF
--- a/src/theme/components/VPBArchives.vue
+++ b/src/theme/components/VPBArchives.vue
@@ -7,54 +7,57 @@ const { theme } = useData();
 </script>
 
 <template>
-  <div class="mx-auto max-w-screen-xl px-6 lg:px-16 lg:py-16">
-    <div class="mx-auto mb-8 max-w-screen-sm text-center lg:mb-16">
-      <h2
-        class="mb-4 text-3xl font-extrabold tracking-tight text-[color:var(--vp-c-brand-light)] dark:text-[color:var(--vp-c-brand-dark)] lg:text-4xl"
-      >
-        {{ theme.blog?.title }} Archives
-      </h2>
-      <p
-        class="font-light text-[color:var(--vp-c-text-light-1)] dark:text-[color:var(--vp-c-text-dark-1)] sm:text-xl"
-      >
-        {{ theme.blog?.description }}
-      </p>
-    </div>
-
-    <div v-for="(year, yearIndex) in postsByYear" :key="yearIndex">
-      <div
-        class="px-0 pb-2 pt-4 text-xl font-semibold leading-6 text-[color:var(--vp-c-brand-light)] dark:text-[color:var(--vp-c-brand-dark)]"
-      >
-        {{ year[0].date.raw.split('-')[0] }}
+  <section class="vpb-shell mx-auto max-w-screen-2xl px-4 py-8 sm:px-6 lg:px-10 lg:py-16">
+    <div class="vpb-page rounded-[2rem] px-6 py-10 sm:px-10 lg:px-14 lg:py-14">
+      <div class="vpb-page-header mx-auto max-w-3xl text-center">
+        <p class="vpb-kicker">Archive</p>
+        <h2 class="vpb-display-title">
+          {{ theme.blog?.title }} Archives
+        </h2>
+        <p class="vpb-lead">
+          {{ theme.blog?.description }}
+        </p>
       </div>
-      <a
-        v-for="(post, index) in year"
-        :key="index"
-        :href="withBase(post.url)"
-        class="m-2 flex cursor-pointer items-center justify-between leading-6 hover:text-[color:var(--vp-c-brand-dark)] dark:hover:text-[color:var(--vp-c-brand-light)]"
-      >
-        <div class="cursor-pointer leading-6">
-          <div class="title-o"></div>
-          {{ post.title }}
+
+      <div class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <div class="space-y-8">
+          <section
+            v-for="(year, yearIndex) in postsByYear"
+            :key="yearIndex"
+            class="vpb-card rounded-[1.5rem] px-5 py-4 sm:px-7 sm:py-6"
+          >
+            <h3 class="vpb-divider-title">
+              {{ year[0].date.raw.split('-')[0] }}
+            </h3>
+            <div class="mt-3">
+              <a
+                v-for="(post, index) in year"
+                :key="index"
+                :href="withBase(post.url)"
+                class="vpb-list-link"
+              >
+                <div class="vpb-list-link__title">{{ post.title }}</div>
+                <div class="vpb-list-link__meta">
+                  {{ post.date.raw.slice(5) }}
+                </div>
+              </a>
+            </div>
+          </section>
         </div>
-        <div class="cursor-pointer font-sans leading-6">
-          {{ post.date.raw.slice(5) }}
-        </div>
-      </a>
+        <aside class="vpb-soft-panel rounded-[1.5rem] p-6">
+          <p class="vpb-kicker">Timeline</p>
+          <p class="mt-4 font-[Iowan_Old_Style,Palatino,'Palatino_Linotype','Book_Antiqua',Georgia,serif] text-2xl leading-tight text-[color:var(--vpb-text-strong)]">
+            A year-by-year map of every published note.
+          </p>
+          <p class="mt-4 text-sm leading-7 text-[color:var(--vpb-text-soft)]">
+            快速按时间回看内容，适合做知识回溯，也让归档页本身更像一本可翻阅的目录。
+          </p>
+        </aside>
+      </div>
     </div>
-  </div>
+  </section>
 </template>
+
 <style>
 @reference "../style.css";
 </style>
-<style scoped>
-h2 {
-  border-top: none;
-  margin-top: 0;
-}
-a {
-  color: inherit;
-  text-decoration: none;
-}
-</style>
-

--- a/src/theme/components/VPBHome.vue
+++ b/src/theme/components/VPBHome.vue
@@ -4,37 +4,30 @@ import { usePosts } from '../composables/usePosts';
 import VPBHomePost from './VPBHomePost.vue';
 
 const { posts } = usePosts();
-
 const { theme } = useData();
 </script>
 
 <template>
-  <div class="mx-auto max-w-screen-xl lg:px-6 lg:py-16">
-    <div class="mx-auto mb-8 max-w-screen-sm text-center lg:mb-16">
-      <h2
-        class="mb-4 text-3xl font-extrabold tracking-tight text-[color:var(--vp-c-brand-light)] dark:text-[color:var(--vp-c-brand-dark)] lg:text-4xl"
-      >
-        {{ theme.blog?.title }}
-      </h2>
-      <p
-        class="font-light text-[color:var(--vp-c-text-light-1)] dark:text-[color:var(--vp-c-text-dark-1)] sm:text-xl"
-      >
-        {{ theme.blog?.description }}
-      </p>
-    </div>
-    <div class="grid gap-6 p-2 lg:grid-cols-2">
-      <div v-for="post of posts" :key="post.url">
-        <VPBHomePost :post="post" />
+  <section class="vpb-shell mx-auto max-w-screen-2xl px-4 py-8 sm:px-6 lg:px-10 lg:py-16">
+    <div class="vpb-page rounded-[2rem] px-6 py-10 sm:px-10 lg:px-14 lg:py-14">
+      <div class="vpb-page-header mx-auto max-w-3xl text-center">
+        <p class="vpb-kicker">Journal</p>
+        <h2 class="vpb-display-title">
+          {{ theme.blog?.title }}
+        </h2>
+        <p class="vpb-lead">
+          {{ theme.blog?.description }}
+        </p>
+      </div>
+      <div class="grid gap-6 lg:grid-cols-2 xl:gap-8">
+        <div v-for="post of posts" :key="post.url">
+          <VPBHomePost :post="post" />
+        </div>
       </div>
     </div>
-  </div>
+  </section>
 </template>
-<style scoped>
-h2 {
-  border-top: none;
-  margin-top: 0;
-}
-</style>
+
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBHomeAuthor.vue
+++ b/src/theme/components/VPBHomeAuthor.vue
@@ -1,52 +1,42 @@
 <script setup>
-import { useData, withBase } from 'vitepress'
-import { computed } from 'vue'
-import { useAuthors } from '../composables/useAuthors'
+import { computed } from 'vue';
+import { withBase } from 'vitepress';
+import { useAuthors } from '../composables/useAuthors';
 
 const props = defineProps({
   name: String
-})
+});
 
-const { site } = useData()
-
-const { findByName } = useAuthors()
+const { findByName } = useAuthors();
 const author = computed(() => {
-  return findByName(props?.name)
-})
-
+  return findByName(props?.name);
+});
 </script>
 
 <template>
-  <div v-if="author" class="flex items-center space-x-4">
+  <div v-if="author" class="flex items-center gap-3">
     <img
       v-if="author?.avatar"
-      class="h-7 w-7 rounded-full"
+      class="h-9 w-9 rounded-full border border-[color:var(--vpb-panel-border)] object-cover"
       :src="withBase(author?.avatar)"
       :alt="author?.name"
     />
     <img
       v-else-if="author?.gravatar"
-      class="h-7 w-7 rounded-full"
+      class="h-9 w-9 rounded-full border border-[color:var(--vpb-panel-border)] object-cover"
       :src="`https://gravatar.com/avatar/${author?.gravatar}`"
       :alt="author?.name"
     />
     <a
       :href="withBase(author.url)"
-      class="inline-flex items-center font-medium hover:text-[color:var(--vp-c-brand-dark)]"
-      ><span class="font-medium dark:text-white">
-        {{ author?.name }}
-      </span>
+      class="vpb-link inline-flex items-center text-sm font-semibold tracking-[0.02em] text-[color:var(--vpb-text-strong)]"
+    >
+      <span>{{ author?.name }}</span>
     </a>
   </div>
   <div v-else />
 </template>
 
-<style scoped>
-a {
-  color: inherit;
-  text-decoration: none;
-}
-</style>
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBHomePost.vue
+++ b/src/theme/components/VPBHomePost.vue
@@ -1,7 +1,7 @@
 <script setup>
-import VPBPostCategory from './VPBPostCategory.vue'
-import VPBHomeAuthor from './VPBHomeAuthor.vue'
-import {withBase} from "vitepress";
+import { withBase } from 'vitepress';
+import VPBHomeAuthor from './VPBHomeAuthor.vue';
+import VPBPostCategory from './VPBPostCategory.vue';
 
 defineProps({
   post: {
@@ -12,41 +12,32 @@ defineProps({
 </script>
 
 <template>
-  <article
-    class="rounded-lg border border-[color:var(--vp-c-brand-light)] p-6 shadow-md dark:border-[color:var(--vp-c-brand-dark)]"
-  >
-    <div class="mb-5 flex items-center justify-between text-gray-500">
-      <span
-        class="bg-primary-100 inline-flex items-center rounded text-sm font-medium text-[color:var(--vp-c-brand-light)] dark:text-[color:var(--vp-c-brand-dark)]"
-      >
+  <article class="vpb-card flex h-full flex-col rounded-[1.75rem] p-6 sm:p-8">
+    <div class="vpb-meta mb-6 flex items-center justify-between gap-4">
+      <span class="vpb-pill rounded-full px-3 py-2">
         <VPBPostCategory :category="post?.category">
-          <span class="text-sm">{{ post.date.since }}</span>
+          <span>{{ post.date.since }}</span>
         </VPBPostCategory>
       </span>
+      <span class="font-['Avenir_Next_Condensed','Franklin_Gothic_Medium',sans-serif] text-[0.8rem] font-semibold uppercase tracking-[0.22em]">
+        {{ post.date.raw }}
+      </span>
     </div>
-    <h2
-      class="mb-2 text-2xl font-bold tracking-tight text-[color:var(--vp-c-brand-light)] dark:text-[color:var(--vp-c-brand-dark)]"
-    >
-      <a :href="withBase(post.url)">{{ post.title }}</a>
+    <h2 class="mb-4 font-[Iowan_Old_Style,Palatino,'Palatino_Linotype','Book_Antiqua',Georgia,serif] text-3xl font-semibold leading-tight tracking-[-0.04em] text-[color:var(--vpb-text-strong)]">
+      <a :href="withBase(post.url)" class="vpb-link">{{ post.title }}</a>
     </h2>
-    <div class="mb-5 font-light" v-html="post.excerpt"></div>
-    <div class="flex items-center justify-between">
+    <div class="vpb-prose mb-8 text-[1.02rem]" v-html="post.excerpt"></div>
+    <div class="mt-auto flex items-center justify-between gap-4 border-t border-[color:var(--vpb-grid-line)] pt-5">
       <VPBHomeAuthor :name="post.author" />
-      <a
-        :href="withBase(post.url)"
-        class="inline-flex items-center font-medium hover:text-[color:var(--vp-c-brand-dark)]"
-      >
+      <a :href="withBase(post.url)" class="vpb-accent-link">
         Read more
         <div class="i-[carbon--arrow-right] ml-2" />
       </a>
     </div>
   </article>
 </template>
+
 <style scoped>
-a {
-  color: inherit;
-  text-decoration: none;
-}
 h2 {
   margin-top: 0;
 }

--- a/src/theme/components/VPBLayoutAuthorAsideBottom.vue
+++ b/src/theme/components/VPBLayoutAuthorAsideBottom.vue
@@ -1,30 +1,20 @@
 <script setup>
-import { useData, withBase } from 'vitepress'
+import { useData, withBase } from 'vitepress';
 
-const { site } = useData()
+const { site } = useData();
 
-const theme = site.value.themeConfig
-const path = withBase(theme.blog?.path ?? '/blog/')
+const theme = site.value.themeConfig;
+const path = withBase(theme.blog?.path ?? '/blog/');
 </script>
 
 <template>
-  <footer
-    class="mb-24 divide-y divide-gray-200 text-sm font-medium leading-5 dark:divide-slate-200/5"
-  >
+  <footer class="vpb-soft-panel mb-24 rounded-[1.75rem] px-5 py-4 text-sm font-medium leading-5">
     <div class="pt-3">
-      <a class="link" :href="path">← Back to the blog</a>
+      <a class="vpb-accent-link" :href="path">← Back to the blog</a>
     </div>
   </footer>
 </template>
 
-<style scoped>
-a {
-  font-weight: 500;
-  color: var(--vp-c-brand);
-  text-decoration-style: dotted;
-  transition: color 0.25s;
-}
-</style>
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBLayoutAuthorTop.vue
+++ b/src/theme/components/VPBLayoutAuthorTop.vue
@@ -6,31 +6,37 @@ const { author, prevAuthor, nextAuthor } = useAuthors();
 </script>
 
 <template>
-  <div>
-    <div class="mb-1 flex items-center justify-between text-gray-500">
-      <img
-        v-if="author?.gravatar"
-        :src="`https://gravatar.com/avatar/${author?.gravatar}`"
-        alt="author image"
-        class="h-20 w-20 rounded-full"
-      />
-      <img
-        v-else-if="author?.avatar"
-        :src="withBase(author?.avatar)"
-        alt="author image"
-        class="h-20 w-20 rounded-full"
-      />
-      <span
-        class="ml-4 text-4xl text-[color:var(--vp-c-brand-light)] dark:text-[color:var(--vp-c-brand-dark)]"
-      >
-        {{ author?.name }}
-      </span>
+  <header class="vpb-soft-panel mb-10 rounded-[2rem] px-6 py-7 sm:px-8">
+    <div class="flex flex-col gap-6 sm:flex-row sm:items-center sm:justify-between">
+      <div class="flex items-center gap-4">
+        <img
+          v-if="author?.gravatar"
+          :src="`https://gravatar.com/avatar/${author?.gravatar}`"
+          alt="author image"
+          class="h-20 w-20 rounded-full border border-[color:var(--vpb-panel-border)] object-cover"
+        />
+        <img
+          v-else-if="author?.avatar"
+          :src="withBase(author?.avatar)"
+          alt="author image"
+          class="h-20 w-20 rounded-full border border-[color:var(--vpb-panel-border)] object-cover"
+        />
+        <div>
+          <p class="vpb-kicker !mb-2">Author</p>
+          <span class="font-[Iowan_Old_Style,Palatino,'Palatino_Linotype','Book_Antiqua',Georgia,serif] text-4xl tracking-[-0.04em] text-[color:var(--vpb-text-strong)]">
+            {{ author?.name }}
+          </span>
+        </div>
+      </div>
+      <p class="max-w-md text-sm leading-7 text-[color:var(--vpb-text-soft)]">
+        A focused author profile with cleaner navigation and warmer editorial styling.
+      </p>
     </div>
-    <div class="mt-4 flex items-center justify-between text-gray-500">
+    <div class="mt-6 flex items-center justify-between gap-4 border-t border-[color:var(--vpb-grid-line)] pt-5 text-[color:var(--vpb-text-soft)]">
       <a
         v-if="prevAuthor"
         :href="withBase(prevAuthor.url)"
-        class="inline-flex items-center font-medium hover:text-[color:var(--vp-c-brand-dark)] dark:text-white"
+        class="vpb-accent-link"
       >
         <div class="i-[carbon--arrow-left] mr-2"></div>
         <span>Previous Author</span>
@@ -39,14 +45,15 @@ const { author, prevAuthor, nextAuthor } = useAuthors();
       <a
         v-if="nextAuthor"
         :href="withBase(nextAuthor.url)"
-        class="inline-flex items-center font-medium hover:text-[color:var(--vp-c-brand-dark)] dark:text-white"
+        class="vpb-accent-link"
       >
         <span>Next Author</span>
         <div class="i-[carbon--arrow-right] ml-2"></div>
       </a>
     </div>
-  </div>
+  </header>
 </template>
+
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBLayoutPostAsideTop.vue
+++ b/src/theme/components/VPBLayoutPostAsideTop.vue
@@ -1,37 +1,39 @@
 <script setup>
-import { useData, withBase } from 'vitepress'
-import { usePosts } from '../composables/usePosts'
-import VPBPostAuthor from './VPBPostAuthor.vue'
-import VPBPostCategory from './VPBPostCategory.vue'
-import VPBTagIcon from './VPBTagIcon.vue'
+import { useData, withBase } from 'vitepress';
+import { usePosts } from '../composables/usePosts';
+import VPBPostAuthor from './VPBPostAuthor.vue';
+import VPBPostCategory from './VPBPostCategory.vue';
+import VPBTagIcon from './VPBTagIcon.vue';
 
-const { site } = useData()
-const { post } = usePosts()
-const theme = site.value.themeConfig
-const path = theme.blog?.tagsPath ?? '/blog/tags'
+const { site } = useData();
+const { post } = usePosts();
+const theme = site.value.themeConfig;
+const path = theme.blog?.tagsPath ?? '/blog/tags';
 </script>
 
 <template>
-  <span
-    class="bg-primary-100 inline-flex items-center rounded text-sm font-medium"
-  >
-    <VPBPostCategory :category="post.category"></VPBPostCategory>
+  <span class="vpb-pill rounded-full px-4 py-2">
+    <VPBPostCategory :category="post.category" />
   </span>
-  <span class="bg-primary-100 inline-flex rounded text-sm font-medium">
-    <div class="flex flex-wrap gap-2 py-5">
+  <div class="vpb-soft-panel mt-4 rounded-[1.5rem] p-4">
+    <div class="mb-3 font-['Avenir_Next_Condensed','Franklin_Gothic_Medium',sans-serif] text-xs uppercase tracking-[0.22em] text-[color:var(--vpb-text-soft)]">
+      Tagged in
+    </div>
+    <div class="flex flex-wrap gap-2">
       <a
         v-for="tagName in post.tags"
         :key="tagName"
-        class="rounded-sm bg-gray-100 px-2 py-1 text-xs font-semibold text-gray-600 flex items-center"
+        class="vpb-chip rounded-full px-3 py-1.5 text-xs font-semibold no-underline"
         :href="`${withBase(path)}?init=${tagName}`"
       >
         <VPBTagIcon :tag="tagName" />
         {{ tagName }}
       </a>
     </div>
-  </span>
+  </div>
   <VPBPostAuthor />
 </template>
+
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBLayoutPostTop.vue
+++ b/src/theme/components/VPBLayoutPostTop.vue
@@ -7,16 +7,16 @@ const { post } = usePosts();
 </script>
 
 <template>
-  <header class="space-y-1 pt-6 text-center xl:pb-10">
+  <header class="vpb-page-header space-y-3 pt-6 text-center xl:pb-10">
+    <p class="vpb-kicker">Feature</p>
     <VPBPostDate />
-    <h1
-      class="md:leading-14 text-3xl font-extrabold leading-9 tracking-tight text-[color:var(--vp-c-brand-dark)] dark:text-[color:var(--vp-c-brand-light)] sm:text-4xl sm:leading-10 md:text-5xl"
-    >
+    <h1 class="vpb-page-title md:text-5xl">
       {{ post.title }}
     </h1>
   </header>
   <VPBPostDetails inside-doc />
 </template>
+
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBPostAuthor.vue
+++ b/src/theme/components/VPBPostAuthor.vue
@@ -1,50 +1,51 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { withBase } from 'vitepress'
-import { usePosts } from '../composables/usePosts'
-import { useAuthors } from '../composables/useAuthors'
+import { computed } from 'vue';
+import { withBase } from 'vitepress';
+import { usePosts } from '../composables/usePosts';
+import { useAuthors } from '../composables/useAuthors';
 
 defineProps<{
   insideDoc?: boolean
-}>()
+}>();
 
-const { findByName } = useAuthors()
-const { post } = usePosts()
+const { findByName } = useAuthors();
+const { post } = usePosts();
 
 const author = computed(() => {
-  return findByName(post.value.author)
-})
+  return findByName(post.value.author);
+});
 </script>
 
 <template>
   <dl
-    class="pb-10 pt-6 xl:border-b xl:border-gray-200 xl:pt-11 dark:xl:border-slate-200/5"
+    class="pb-10 pt-6 xl:pt-8"
     :class="{ 'xs:show xl:hidden': insideDoc }"
   >
     <dt class="sr-only">Authors</dt>
     <dd>
-      <ul
-        class="flex justify-center space-x-8 sm:space-x-12 xl:block xl:space-x-0 xl:space-y-8"
-      >
-        <li v-if="author" class="flex items-center space-x-2">
+      <ul class="flex justify-center sm:space-x-12 xl:block xl:space-x-0 xl:space-y-8">
+        <li
+          v-if="author"
+          class="vpb-soft-panel flex items-center gap-3 rounded-[1.5rem] px-4 py-4"
+        >
           <img
             v-if="author?.gravatar"
             :src="`https://gravatar.com/avatar/${author?.gravatar}`"
             alt="author image"
-            class="h-10 w-10 rounded-full"
+            class="h-12 w-12 rounded-full border border-[color:var(--vpb-panel-border)] object-cover"
           />
           <img
             v-else-if="author?.avatar"
             :src="withBase(author?.avatar)"
             alt="author image"
-            class="h-10 w-10 rounded-full"
+            class="h-12 w-12 rounded-full border border-[color:var(--vpb-panel-border)] object-cover"
           />
-          <dl class="whitespace-nowrap text-sm font-medium leading-5">
+          <dl class="min-w-0 text-sm font-medium leading-5">
             <dt class="sr-only">Name</dt>
-            <dd class="text-gray-900 dark:text-white">
+            <dd class="text-[color:var(--vpb-text-strong)]">
               <a
                 :href="withBase(author.url)"
-                class="text-lg text-gray-900 hover:text-[color:var(--vp-c-brand-light)] dark:text-white dark:hover:text-[color:var(--vp-c-brand-dark)]"
+                class="vpb-link font-[Iowan_Old_Style,Palatino,'Palatino_Linotype','Book_Antiqua',Georgia,serif] text-xl tracking-[-0.02em]"
               >
                 {{ author?.name }}
               </a>
@@ -55,8 +56,10 @@ const author = computed(() => {
                 :href="`https://twitter.com/${author?.twitter}`"
                 target="_blank"
                 rel="noopener noreferrer"
-                >@{{ author.twitter }}</a
+                class="vpb-link text-xs uppercase tracking-[0.2em] text-[color:var(--vpb-text-soft)]"
               >
+                @{{ author.twitter }}
+              </a>
             </dd>
           </dl>
         </li>
@@ -65,14 +68,6 @@ const author = computed(() => {
   </dl>
 </template>
 
-<style scoped>
-a {
-  font-weight: 500;
-  color: var(--vp-c-brand);
-  text-decoration-style: dotted;
-  transition: color 0.25s;
-}
-</style>
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBPostCategory.vue
+++ b/src/theme/components/VPBPostCategory.vue
@@ -1,11 +1,12 @@
 <script setup>
 import { computed } from 'vue';
-import { useData } from 'vitepress'
+import { useData } from 'vitepress';
 
 const props = defineProps({
   category: String
-})
-const { theme } = useData()
+});
+
+const { theme } = useData();
 const iconClass = computed(() => {
   const category = props.category?.toLowerCase();
   return category ? theme.value.blog?.categoryIcons?.[category] ?? null : null;
@@ -13,24 +14,17 @@ const iconClass = computed(() => {
 </script>
 
 <template>
-  <div class="flex items-center">
+  <div class="flex items-center gap-2">
     <span
       v-if="iconClass"
       :class="iconClass"
-      class="mr-2"
+      class="text-[0.95em]"
     />
     <span>{{ props.category }}</span>
+    <slot />
   </div>
 </template>
 
-<style scoped>
-a {
-  font-weight: 500;
-  color: var(--vp-c-brand);
-  text-decoration-style: dotted;
-  transition: color 0.25s;
-}
-</style>
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBPostDate.vue
+++ b/src/theme/components/VPBPostDate.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { usePosts } from '../composables/usePosts';
+
 const { post } = usePosts();
 
 function getDateTime() {
@@ -10,13 +11,12 @@ function getDateTime() {
 <template>
   <dl>
     <dt class="sr-only">Published on</dt>
-    <dd
-      class="text-base font-medium leading-6 text-gray-500 dark:text-gray-300"
-    >
+    <dd class="vpb-meta font-['Avenir_Next_Condensed','Franklin_Gothic_Medium',sans-serif] text-sm font-semibold uppercase tracking-[0.24em]">
       <time :datetime="getDateTime()">{{ post.date.formatted }}</time>
     </dd>
   </dl>
 </template>
+
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBPostDetails.vue
+++ b/src/theme/components/VPBPostDetails.vue
@@ -1,28 +1,27 @@
 <script setup>
-import { usePosts } from '../composables/usePosts'
-import VPBPostCategory from './VPBPostCategory.vue'
-import VPBPostAuthor from './VPBPostAuthor.vue'
+import { usePosts } from '../composables/usePosts';
+import VPBPostCategory from './VPBPostCategory.vue';
+import VPBPostAuthor from './VPBPostAuthor.vue';
 
 defineProps({
   insideDoc: Boolean
-})
+});
 
-const { post } = usePosts()
+const { post } = usePosts();
 </script>
 
 <template>
   <div
-    class="flex justify-center space-x-8 sm:space-x-12 xl:block xl:space-x-0 xl:space-y-8"
+    class="mb-6 flex justify-center sm:space-x-12 xl:mb-0 xl:block xl:space-x-0 xl:space-y-8"
     :class="{ 'xs:show xl:hidden': insideDoc }"
   >
-    <span
-      class="bg-primary-100 inline-flex items-center rounded text-sm font-medium"
-    >
+    <span class="vpb-pill rounded-full px-4 py-2">
       <VPBPostCategory :category="post?.category" />
     </span>
   </div>
   <VPBPostAuthor inside-doc />
 </template>
+
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBPostLinks.vue
+++ b/src/theme/components/VPBPostLinks.vue
@@ -1,53 +1,55 @@
 <script setup>
-import { useData, withBase } from 'vitepress'
-import { usePosts } from '../composables/usePosts'
+import { useData, withBase } from 'vitepress';
+import { usePosts } from '../composables/usePosts';
 
 defineProps({
   insideDoc: Boolean
-})
+});
 
-const { site } = useData()
-const { nextPost, prevPost } = usePosts()
+const { site } = useData();
+const { nextPost, prevPost } = usePosts();
 
-const theme = site.value.themeConfig
-const path = theme.blog?.path ?? '/blog/'
+const theme = site.value.themeConfig;
+const path = theme.blog?.path ?? '/blog/';
 </script>
 
 <template>
   <footer
-    class="mb-24 divide-y divide-gray-200 text-sm font-medium leading-5 dark:divide-slate-200/5"
+    class="vpb-soft-panel mb-24 rounded-[1.75rem] px-5 py-4 text-sm font-medium leading-5"
     :class="{ 'xs:show lg:hidden': insideDoc }"
   >
-    <div v-if="nextPost" class="py-3">
-      <h2 class="text-xs uppercase tracking-wide text-gray-500 dark:text-white">
+    <div v-if="nextPost" class="border-b border-[color:var(--vpb-grid-line)] py-3">
+      <h2 class="vpb-meta mb-2 font-['Avenir_Next_Condensed','Franklin_Gothic_Medium',sans-serif] text-xs uppercase tracking-[0.22em]">
         Next Article
       </h2>
-      <div class="link">
-        <a :href="`${withBase(nextPost.url)}`">{{ nextPost.title }}</a>
+      <div>
+        <a
+          class="vpb-link font-[Iowan_Old_Style,Palatino,'Palatino_Linotype','Book_Antiqua',Georgia,serif] text-xl tracking-[-0.02em] text-[color:var(--vpb-text-strong)]"
+          :href="`${withBase(nextPost.url)}`"
+        >
+          {{ nextPost.title }}
+        </a>
       </div>
     </div>
-    <div v-if="prevPost" class="py-3">
-      <h2 class="text-xs uppercase tracking-wide text-gray-500 dark:text-white">
+    <div v-if="prevPost" class="border-b border-[color:var(--vpb-grid-line)] py-3">
+      <h2 class="vpb-meta mb-2 font-['Avenir_Next_Condensed','Franklin_Gothic_Medium',sans-serif] text-xs uppercase tracking-[0.22em]">
         Previous Article
       </h2>
-      <div class="link">
-        <a :href="`${withBase(prevPost.url)}`"> {{ prevPost.title }}</a>
+      <div>
+        <a
+          class="vpb-link font-[Iowan_Old_Style,Palatino,'Palatino_Linotype','Book_Antiqua',Georgia,serif] text-xl tracking-[-0.02em] text-[color:var(--vpb-text-strong)]"
+          :href="`${withBase(prevPost.url)}`"
+        >
+          {{ prevPost.title }}
+        </a>
       </div>
     </div>
     <div class="pt-3">
-      <a class="link" :href="withBase(path)">← Back to the blog</a>
+      <a class="vpb-accent-link" :href="withBase(path)">← Back to the blog</a>
     </div>
   </footer>
 </template>
 
-<style scoped>
-a {
-  font-weight: 500;
-  color: var(--vp-c-brand);
-  text-decoration-style: dotted;
-  transition: color 0.25s;
-}
-</style>
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/components/VPBTags.vue
+++ b/src/theme/components/VPBTags.vue
@@ -7,12 +7,14 @@ import VPBTagIcon from './VPBTagIcon.vue';
 const { postsByTag } = useTags();
 const { theme } = useData();
 const selectedTag = ref('');
+
 function toggleTag(tag) {
   selectedTag.value = tag;
 }
+
 if (inBrowser) {
   const params = new URLSearchParams(window.location.search);
-  const init = params.get('init'); // returns the number 123
+  const init = params.get('init');
   if (init) {
     toggleTag(init);
   }
@@ -21,81 +23,78 @@ if (inBrowser) {
 
 <template>
   <ClientOnly>
-    <div class="mx-auto max-w-screen-xl px-6 lg:px-16 lg:py-16">
-      <div class="mx-auto mb-8 max-w-screen-sm text-center lg:mb-16">
-        <h2
-          class="mb-4 text-3xl font-extrabold tracking-tight text-[color:var(--vp-c-brand-light)] dark:text-[color:var(--vp-c-brand-dark)] lg:text-4xl"
-        >
-          {{ theme.blog?.title }} Tags
-        </h2>
-        <p
-          class="font-light text-[color:var(--vp-c-text-light-1)] dark:text-[color:var(--vp-c-text-dark-1)] sm:text-xl"
-        >
-          {{ theme.blog?.description }}
-        </p>
-      </div>
-      <div class="flex flex-wrap justify-center gap-2 p-4 ">
-        <div
-          v-for="(posts, tagName) in postsByTag"
-          :key="tagName"
-          class="flex items-center"
-          :class="{
-            'cursor-pointer rounded-full bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-600':
-              selectedTag !== tagName,
-            'rounded-full bg-[color:var(--vp-c-brand-light)] px-3 py-1 text-sm font-semibold text-gray-100 dark:bg-[color:var(--vp-c-brand-dark)]':
-              selectedTag === tagName,
-          }"
-          @click="toggleTag(tagName)"
-        >
-          <VPBTagIcon :tag="tagName" />
-          {{ tagName }}
-          <span
-            :class="{
-              'ml-3 text-[color:var(--vp-c-brand-light)] dark:text-[color:var(--vp-c-brand-dark)]':
-                selectedTag !== tagName,
-              'ml-3 text-[color:var(--vp-c-brand-dark)] dark:text-[color:var(--vp-c-brand-light)]':
-                selectedTag === tagName,
-            }"
-            >{{ posts.length }}</span
-          >
+    <section class="vpb-shell mx-auto max-w-screen-2xl px-4 py-8 sm:px-6 lg:px-10 lg:py-16">
+      <div class="vpb-page rounded-[2rem] px-6 py-10 sm:px-10 lg:px-14 lg:py-14">
+        <div class="vpb-page-header mx-auto max-w-3xl text-center">
+          <p class="vpb-kicker">Index</p>
+          <h2 class="vpb-display-title">
+            {{ theme.blog?.title }} Tags
+          </h2>
+          <p class="vpb-lead">
+            {{ theme.blog?.description }}
+          </p>
         </div>
-      </div>
 
-      <div v-if="selectedTag">
-        <div
-          class="flex items-center px-0 pb-2 pt-4 text-xl font-semibold leading-6 text-[color:var(--vp-c-brand-light)] dark:text-[color:var(--vp-c-brand-dark)]"
-        >
-          <VPBTagIcon :tag="selectedTag" />{{ selectedTag }}
-          <span class="text-xs"> ( {{ postsByTag[selectedTag].length }} )</span>
+        <div class="mb-8 flex flex-wrap justify-center gap-3">
+          <button
+            v-for="(posts, tagName) in postsByTag"
+            :key="tagName"
+            type="button"
+            class="vpb-chip cursor-pointer rounded-full px-4 py-2 text-sm font-semibold"
+            :class="{ 'is-active': selectedTag === tagName }"
+            @click="toggleTag(tagName)"
+          >
+            <VPBTagIcon :tag="tagName" />
+            <span>{{ tagName }}</span>
+            <span class="rounded-full bg-[color:var(--vp-c-brand-dimm)] px-2 py-0.5 text-xs">
+              {{ posts.length }}
+            </span>
+          </button>
         </div>
-        <a
-          v-for="(post, index) in postsByTag[selectedTag]"
-          :key="index"
-          :href="withBase(post.url)"
-          class="m-2 flex cursor-pointer items-center justify-between leading-6"
+
+        <section
+          v-if="selectedTag"
+          class="vpb-card mx-auto max-w-4xl rounded-[1.75rem] px-5 py-5 sm:px-8 sm:py-7"
         >
-          <div class="cursor-pointer leading-6">
-            <div class="title-o"></div>
-            {{ post.title }}
+          <div class="mb-3 flex items-center gap-3">
+            <span class="vpb-pill rounded-full px-3 py-2">
+              <VPBTagIcon :tag="selectedTag" />
+              {{ selectedTag }}
+            </span>
+            <span class="vpb-meta">
+              {{ postsByTag[selectedTag].length }} posts
+            </span>
           </div>
-          <div class="cursor-pointer font-sans leading-6">
-            {{ post.date.raw }}
-          </div>
-        </a>
+          <a
+            v-for="(post, index) in postsByTag[selectedTag]"
+            :key="index"
+            :href="withBase(post.url)"
+            class="vpb-list-link"
+          >
+            <div class="vpb-list-link__title">{{ post.title }}</div>
+            <div class="vpb-list-link__meta">
+              {{ post.date.raw }}
+            </div>
+          </a>
+        </section>
+
+        <section
+          v-else
+          class="vpb-soft-panel mx-auto max-w-2xl rounded-[1.75rem] px-6 py-10 text-center"
+        >
+          <p class="vpb-kicker">Browse</p>
+          <p class="mt-4 font-[Iowan_Old_Style,Palatino,'Palatino_Linotype','Book_Antiqua',Georgia,serif] text-2xl leading-tight text-[color:var(--vpb-text-strong)]">
+            Pick a tag to open a curated slice of the archive.
+          </p>
+          <p class="mt-4 text-sm leading-7 text-[color:var(--vpb-text-soft)]">
+            标签列表现在更像索引面板，适合快速筛选主题，而不是一堆松散按钮。
+          </p>
+        </section>
       </div>
-    </div>
+    </section>
   </ClientOnly>
 </template>
-<style scoped>
-h2 {
-  border-top: none;
-  margin-top: 0;
-}
-a {
-  color: inherit;
-  text-decoration: none;
-}
-</style>
+
 <style>
 @reference "../style.css";
 </style>

--- a/src/theme/style.css
+++ b/src/theme/style.css
@@ -16,20 +16,50 @@
 @plugin "@iconify/tailwind4" {
   prefix: "i";
   scale: 1.2;
-};
+}
 
 /**
  * Colors
  * -------------------------------------------------------------------------- */
 
 :root {
-    --vp-c-brand: #646cff;
-    --vp-c-brand-light: #747bff;
-    --vp-c-brand-lighter: #9499ff;
-    --vp-c-brand-lightest: #bcc0ff;
-    --vp-c-brand-dark: #535bf2;
-    --vp-c-brand-darker: #454ce1;
-    --vp-c-brand-dimm: rgba(100, 108, 255, 0.08);
+    --vp-c-brand: #a5482f;
+    --vp-c-brand-light: #c46445;
+    --vp-c-brand-lighter: #dd8d72;
+    --vp-c-brand-lightest: #f2d2c3;
+    --vp-c-brand-dark: #893621;
+    --vp-c-brand-darker: #642415;
+    --vp-c-brand-dimm: rgba(165, 72, 47, 0.12);
+    --vpb-bg: #f7f1e8;
+    --vpb-bg-soft: rgba(255, 251, 245, 0.84);
+    --vpb-bg-strong: rgba(255, 248, 239, 0.96);
+    --vpb-panel-border: rgba(117, 70, 47, 0.14);
+    --vpb-panel-shadow: 0 24px 70px rgba(89, 51, 31, 0.12);
+    --vpb-panel-shadow-hover: 0 28px 88px rgba(89, 51, 31, 0.18);
+    --vpb-text-strong: #2f211c;
+    --vpb-text-soft: #70534a;
+    --vpb-grid-line: rgba(117, 70, 47, 0.1);
+    --vpb-accent-glow: radial-gradient(circle at top, rgba(218, 145, 101, 0.24), transparent 58%);
+}
+
+.dark {
+    --vp-c-brand: #f0a17f;
+    --vp-c-brand-light: #f6b293;
+    --vp-c-brand-lighter: #f8cbb6;
+    --vp-c-brand-lightest: #ffe6da;
+    --vp-c-brand-dark: #d67d57;
+    --vp-c-brand-darker: #ba6540;
+    --vp-c-brand-dimm: rgba(240, 161, 127, 0.16);
+    --vpb-bg: #16110f;
+    --vpb-bg-soft: rgba(31, 24, 21, 0.84);
+    --vpb-bg-strong: rgba(36, 28, 24, 0.94);
+    --vpb-panel-border: rgba(255, 222, 204, 0.12);
+    --vpb-panel-shadow: 0 24px 70px rgba(0, 0, 0, 0.28);
+    --vpb-panel-shadow-hover: 0 28px 88px rgba(0, 0, 0, 0.36);
+    --vpb-text-strong: #f9eadf;
+    --vpb-text-soft: #c4a99c;
+    --vpb-grid-line: rgba(255, 223, 206, 0.08);
+    --vpb-accent-glow: radial-gradient(circle at top, rgba(240, 161, 127, 0.18), transparent 55%);
 }
 
 /**
@@ -56,14 +86,15 @@
     --vp-home-hero-name-color: transparent;
     --vp-home-hero-name-background: -webkit-linear-gradient(
             120deg,
-            #bd34fe 30%,
-            #41d1ff
+            #8a2c21 20%,
+            #d97d4f 55%,
+            #f0c59a
     );
 
     --vp-home-hero-image-background-image: linear-gradient(
             -45deg,
-            #bd34fe 50%,
-            #47caff 50%
+            #d97d4f 35%,
+            #f0c59a 100%
     );
     --vp-home-hero-image-filter: blur(40px);
 }
@@ -104,3 +135,327 @@
     --docsearch-primary-color: var(--vp-c-brand) !important;
 }
 
+body {
+    background:
+            var(--vpb-accent-glow),
+            linear-gradient(180deg, var(--vpb-bg) 0%, color-mix(in srgb, var(--vpb-bg) 82%, #fff 18%) 100%);
+    color: var(--vpb-text-strong);
+    font-family: "Avenir Next", Avenir, "Segoe UI", sans-serif;
+}
+
+.dark body {
+    background:
+            radial-gradient(circle at top, rgba(240, 161, 127, 0.16), transparent 36%),
+            linear-gradient(180deg, #120e0c 0%, #1a1412 100%);
+}
+
+.vp-doc,
+.VPDoc,
+.VPContent {
+    color: var(--vpb-text-strong);
+}
+
+.vpb-shell {
+    position: relative;
+}
+
+.vpb-shell::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto auto 0;
+    height: 1px;
+    width: 100%;
+    background: linear-gradient(90deg, transparent, var(--vpb-grid-line), transparent);
+}
+
+.vpb-page {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--vpb-panel-border);
+    background: var(--vpb-bg-soft);
+    box-shadow: var(--vpb-panel-shadow);
+    backdrop-filter: blur(18px);
+}
+
+.vpb-page::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+            linear-gradient(90deg, transparent 0, transparent calc(100% - 1px), var(--vpb-grid-line) calc(100% - 1px), var(--vpb-grid-line) 100%),
+            linear-gradient(180deg, transparent 0, transparent calc(100% - 1px), var(--vpb-grid-line) calc(100% - 1px), var(--vpb-grid-line) 100%);
+    opacity: 0.45;
+}
+
+.vpb-page-header {
+    position: relative;
+    margin-bottom: 2.75rem;
+    padding-bottom: 1.25rem;
+}
+
+.vpb-page-header::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    height: 1px;
+    width: min(160px, 40%);
+    transform: translateX(-50%);
+    background: linear-gradient(90deg, transparent, var(--vp-c-brand), transparent);
+}
+
+.vpb-kicker {
+    margin-bottom: 0.9rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    color: var(--vp-c-brand);
+    font-family: "Avenir Next Condensed", "Franklin Gothic Medium", sans-serif;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+}
+
+.vpb-kicker::before,
+.vpb-kicker::after {
+    content: "";
+    display: block;
+    height: 1px;
+    width: 2.4rem;
+    background: color-mix(in srgb, var(--vp-c-brand) 55%, transparent);
+}
+
+.vpb-display-title {
+    margin: 0;
+    border-top: none !important;
+    font-family: Iowan Old Style, Palatino, "Palatino Linotype", "Book Antiqua", Georgia, serif;
+    font-size: clamp(2.5rem, 6vw, 4.75rem);
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    line-height: 0.95;
+    color: var(--vpb-text-strong);
+    text-wrap: balance;
+}
+
+.vpb-page-title {
+    margin: 0;
+    border-top: none !important;
+    font-family: Iowan Old Style, Palatino, "Palatino Linotype", "Book Antiqua", Georgia, serif;
+    font-size: clamp(2.35rem, 4vw, 3.4rem);
+    font-weight: 700;
+    letter-spacing: -0.04em;
+    line-height: 1;
+    color: var(--vpb-text-strong);
+    text-wrap: balance;
+}
+
+.vpb-lead {
+    margin: 1.25rem auto 0;
+    max-width: 46rem;
+    color: var(--vpb-text-soft);
+    font-size: clamp(1rem, 1.8vw, 1.18rem);
+    line-height: 1.8;
+    text-wrap: pretty;
+}
+
+.vpb-card {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--vpb-panel-border);
+    background:
+            linear-gradient(180deg, color-mix(in srgb, var(--vpb-bg-strong) 92%, transparent) 0%, color-mix(in srgb, var(--vpb-bg-soft) 96%, transparent) 100%);
+    box-shadow: var(--vpb-panel-shadow);
+    transition:
+            transform 0.28s ease,
+            box-shadow 0.28s ease,
+            border-color 0.28s ease;
+}
+
+.vpb-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+            radial-gradient(circle at top right, rgba(217, 125, 79, 0.14), transparent 38%),
+            linear-gradient(135deg, rgba(255, 255, 255, 0.22), transparent 30%);
+}
+
+.vpb-card:hover {
+    transform: translateY(-4px);
+    border-color: color-mix(in srgb, var(--vp-c-brand) 30%, var(--vpb-panel-border));
+    box-shadow: var(--vpb-panel-shadow-hover);
+}
+
+.vpb-link {
+    color: inherit;
+    text-decoration: none;
+    transition:
+            color 0.25s ease,
+            opacity 0.25s ease;
+}
+
+.vpb-link:hover {
+    color: var(--vp-c-brand);
+}
+
+.vpb-meta {
+    color: var(--vpb-text-soft);
+    font-size: 0.88rem;
+    letter-spacing: 0.03em;
+}
+
+.vpb-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border: 1px solid color-mix(in srgb, var(--vp-c-brand) 18%, transparent);
+    background: color-mix(in srgb, var(--vp-c-brand-dimm) 78%, var(--vpb-bg-strong));
+    color: var(--vp-c-brand-darker);
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.dark .vpb-pill {
+    color: var(--vp-c-brand-lightest);
+}
+
+.vpb-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    border: 1px solid var(--vpb-panel-border);
+    background: color-mix(in srgb, var(--vpb-bg-strong) 88%, transparent);
+    color: var(--vpb-text-soft);
+    transition:
+            transform 0.2s ease,
+            border-color 0.2s ease,
+            color 0.2s ease,
+            background-color 0.2s ease;
+}
+
+.vpb-chip:hover,
+.vpb-chip.is-active {
+    transform: translateY(-1px);
+    border-color: color-mix(in srgb, var(--vp-c-brand) 32%, var(--vpb-panel-border));
+    background: color-mix(in srgb, var(--vp-c-brand-dimm) 82%, var(--vpb-bg-strong));
+    color: var(--vp-c-brand-darker);
+}
+
+.dark .vpb-chip:hover,
+.dark .vpb-chip.is-active {
+    color: var(--vp-c-brand-lightest);
+}
+
+.vpb-divider-title {
+    position: relative;
+    margin: 0;
+    padding-top: 1.5rem;
+    font-family: "Avenir Next Condensed", "Franklin Gothic Medium", sans-serif;
+    font-size: 1rem;
+    font-weight: 700;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--vp-c-brand);
+}
+
+.vpb-divider-title::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto auto 0;
+    height: 1px;
+    width: 100%;
+    background: linear-gradient(90deg, var(--vpb-grid-line), transparent 85%);
+}
+
+.vpb-list-link {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 1.25rem;
+    border-top: 1px solid var(--vpb-grid-line);
+    padding: 1rem 0;
+    color: inherit;
+    text-decoration: none;
+    transition:
+            color 0.25s ease,
+            transform 0.25s ease;
+}
+
+.vpb-list-link:hover {
+    transform: translateX(3px);
+    color: var(--vp-c-brand);
+}
+
+.vpb-list-link:first-of-type {
+    border-top: none;
+}
+
+.vpb-list-link__title {
+    font-size: 1.05rem;
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    color: var(--vpb-text-strong);
+}
+
+.vpb-list-link__meta {
+    color: var(--vpb-text-soft);
+    font-family: "Avenir Next Condensed", "Franklin Gothic Medium", sans-serif;
+    font-size: 0.84rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.vpb-accent-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    color: var(--vp-c-brand);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    transition:
+            gap 0.2s ease,
+            color 0.2s ease;
+}
+
+.vpb-accent-link:hover {
+    gap: 0.8rem;
+    color: var(--vp-c-brand-dark);
+}
+
+.dark .vpb-accent-link:hover {
+    color: var(--vp-c-brand-light);
+}
+
+.vpb-prose {
+    color: var(--vpb-text-soft);
+    line-height: 1.85;
+}
+
+.vpb-prose :is(p, ul, ol) {
+    margin-top: 0;
+    color: inherit;
+}
+
+.vpb-soft-panel {
+    border: 1px solid var(--vpb-panel-border);
+    background: color-mix(in srgb, var(--vpb-bg-strong) 92%, transparent);
+    box-shadow: var(--vpb-panel-shadow);
+}
+
+@media (max-width: 768px) {
+    .vpb-page {
+        border-left: none;
+        border-right: none;
+        border-radius: 0;
+    }
+
+    .vpb-page::before {
+        opacity: 0.28;
+    }
+}


### PR DESCRIPTION
## What changed
- refreshed the blog theme UI across the core VitePress blog components
- introduced a warmer editorial visual system with shared tokens, glass-like panels, serif headings, and stronger hierarchy
- restyled the home feed, tags page, archives page, post header, author blocks, and post navigation so they feel like one cohesive theme

## Why
- the existing UI was functional but visually fragmented, with repeated one-off utility styling and a default VitePress color feel
- this update makes the theme more distinctive and consistent while keeping the underlying data flow and component responsibilities intact

## Impact
- consumers of the theme get a more polished out-of-the-box blog presentation
- the styling surface is easier to maintain because common visual patterns now live in shared theme classes and tokens

## Validation
- `lint-staged` ran during commit and completed successfully via the repository hooks
- full docs build was not run in this workspace because `node_modules` were missing at the time of local verification
